### PR TITLE
fix: add Hydrogen 17 JS chunk files to static paths array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@netlify/vite-plugin-netlify-edge": "^0.0.1",
+        "fast-glob": "^3.2.11",
         "magic-string": "^0.26.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/netlify/hydrogen-platform#readme",
   "dependencies": {
     "@netlify/vite-plugin-netlify-edge": "^0.0.1",
+    "fast-glob": "^3.2.11",
     "magic-string": "^0.26.1"
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,7 +8,7 @@ import type { Plugin, ResolvedConfig } from 'vite'
 
 const HYDROGEN_DEFAULT_SERVER_ENTRY = '/src/App.server'
 const PLATFORM_MODULE = '@netlify/hydrogen-platform/handler'
-const CLIENT_DIR = 'dist/client'
+const DEFAULT_PUBLISH_DIR = 'dist/client'
 
 const plugin = (): Array<Plugin> => {
   let resolvedConfig: ResolvedConfig
@@ -20,7 +20,7 @@ const plugin = (): Array<Plugin> => {
           .sync('*.js', {
             cwd: path.resolve(
               config.root,
-              process.env.CLIENT_DIR || CLIENT_DIR
+              process.env.PUBLISH_DIR || DEFAULT_PUBLISH_DIR
             ),
           })
           .map((file) => `${config.base}${encodeURIComponent(file)}`),
@@ -56,7 +56,7 @@ const plugin = (): Array<Plugin> => {
                 normalizePath(
                   path.resolve(
                     resolvedConfig.root,
-                    process.env.CLIENT_DIR || CLIENT_DIR,
+                    process.env.PUBLISH_DIR || DEFAULT_PUBLISH_DIR,
                     'index.html'
                   )
                 )

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,7 @@ import type { Plugin, ResolvedConfig } from 'vite'
 
 const HYDROGEN_DEFAULT_SERVER_ENTRY = '/src/App.server'
 const PLATFORM_MODULE = '@netlify/hydrogen-platform/handler'
+const CLIENT_DIR = 'dist/client'
 
 const plugin = (): Array<Plugin> => {
   let resolvedConfig: ResolvedConfig
@@ -17,7 +18,10 @@ const plugin = (): Array<Plugin> => {
       additionalStaticPaths: (config) =>
         glob
           .sync('*.js', {
-            cwd: path.resolve(config.root, 'dist/client'),
+            cwd: path.resolve(
+              config.root,
+              process.env.CLIENT_DIR || CLIENT_DIR
+            ),
           })
           .map((file) => `${config.base}${encodeURIComponent(file)}`),
     }),
@@ -52,8 +56,7 @@ const plugin = (): Array<Plugin> => {
                 normalizePath(
                   path.resolve(
                     resolvedConfig.root,
-                    'dist',
-                    'client',
+                    process.env.CLIENT_DIR || CLIENT_DIR,
                     'index.html'
                   )
                 )

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
 import netlifyPlugin from '@netlify/vite-plugin-netlify-edge'
 import { normalizePath } from 'vite'
 import path from 'path'
+import glob from 'fast-glob'
 import MagicString from 'magic-string'
 
 import type { Plugin, ResolvedConfig } from 'vite'
@@ -12,7 +13,14 @@ const plugin = (): Array<Plugin> => {
   let resolvedConfig: ResolvedConfig
   let platformEntryPath: string
   return [
-    netlifyPlugin(),
+    netlifyPlugin({
+      additionalStaticPaths: (config) =>
+        glob
+          .sync('*.js', {
+            cwd: path.resolve(config.root, 'dist/client'),
+          })
+          .map((file) => `${config.base}${encodeURIComponent(file)}`),
+    }),
     {
       name: 'vite-plugin-netlify-hydrogen',
       configResolved(config) {


### PR DESCRIPTION
Hydrogen 17 obfuscates the JS chunk filenames and relocates them from the dist/client/assets directory to dist/client.

Now that they are no longer in the assets directory, they are not recognised as static files and this PR adds them back explicitly via the `additionalStaticPaths` param to the `@netlify/vite-plugin-netlify-edge` plugin.

Note: this PR is dependent on https://github.com/netlify/vite-plugin-netlify-edge/pull/12