### PR TITLE
feat: support Hydrogen 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hydrogen on Netlify Edge Functions
 
-This package is a Hydrogen platform that allows you to deploy your site to Netlify Edge. The easiest way to get started is using a template, but you can change your existing site to use Netlify Edge Functions by installing this package and following these instructions.
+This package is a Hydrogen platform that allows you to deploy your site to Netlify Edge Functions.
 
 ## Installation
 
@@ -13,27 +13,19 @@ Then add the plugin to your Vite config:
 ```js
 // vite.config.js
 
+import { defineConfig } from 'vite'
+import hydrogen from '@shopify/hydrogen/plugin'
 import netlifyPlugin from '@netlify/hydrogen-platform/plugin'
-import shopifyConfig from './shopify.config'
 
 export default defineConfig({
-  plugins: [hydrogen(shopifyConfig), netlifyPlugin()],
+  plugins: [hydrogen(), netlifyPlugin()],
   //   ...
 })
 ```
 
-You then need to specify the SSR entrypoint in your build command:
+Then when you run `shopify hydrogen build` it will generate the correct files to deploy to Netlify Edge.
 
-```json
-// package.json
-"scripts": {
-    "build" "npm run build:client && npm run build:ssr",
-    "build:client": "vite build --outDir dist/client --manifest",
-    "build:ssr": "cross-env WORKER=true vite build --ssr @netlify/hydrogen-platform/handler",
-}
-```
-
-Your Netlify site should be configured to publish the `dist/client` directory:
+Netlify detects Hydrogen sites, so you should have the correct settings already, but if you need to set them manually you can use the `netlify.toml` or Netlify UI to do so:
 
 ```toml
 # netlify.toml

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,19 +13,17 @@ const handler = async (request: Request, context: any) => {
     return
   }
 
-  // Badly-behaved libraries look for window instead of document to
-  // check if it's in a browser.
-  delete (globalThis as any).window
+  ;(globalThis as any).Oxygen ||= {}
+  // @ts-ignore Deno global is available at runtime
+  ;(globalThis as any).Oxygen.env = Deno.env.toObject()
 
-  // This is where Hydrogen looks for the env var
-  ;(globalThis as any).Oxygen ||= { env: {} }
-  ;(globalThis as any).Oxygen.env.HYDROGEN_ENABLE_WORKER_STREAMING = true
+  // IP is on the context object. By default, this is where Hydrogen looks for it
+  request.headers.set('x-forwarded-for', context.ip)
 
   try {
     return await handleRequest(request, {
       indexTemplate,
       context,
-      buyerIpHeader: 'x-nf-client-connection-ip',
     })
   } catch (error: any) {
     return new Response(error.message || error.toString(), { status: 500 })


### PR DESCRIPTION
Hydrogen now expects to be run via the shopify CLI, rather than by calling Vite directly. This means that we can no longer pass custom flags to vite when compiling, so we need to do it all in the Vite plugin. This PR does this: setting the correct entrypoint and output directories. It can now just be enabled by adding the plugin to the Vite config.

Closes #29