### PR TITLE
ci: automatically update demo sites

### DIFF
--- a/.github/workflows/update-demo-sites.yml
+++ b/.github/workflows/update-demo-sites.yml
@@ -1,0 +1,40 @@
+name: Update demo sites
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Update demo sites from the Hydrogen repository
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Checkout the Hydrogen repo
+        uses: actions/checkout@v3
+        with:
+          repository: Shopify/hydrogen
+          ref: dist
+          path: upstream
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Update local templates
+        run: |
+          node scripts/update-demos.mjs
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.0.4
+        with:
+          commit-message: 'chore: update demo sites from Hydrogen repository'
+          committer: Netlify Bot <bot@netlify.com>
+          author: Netlify Bot <bot@netlify.com>
+          branch: bot/update-demo-sites
+          labels: 'type: chore'
+          delete-branch: true
+          body: |
+            Update demo sites from [the Hydrogen repository](https://github.com/Shopify/hydrogen/tree/dist/templates)

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+upstream

--- a/scripts/templates/demo-store/netlify.toml
+++ b/scripts/templates/demo-store/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "cd ../../ && npm run build && cd - && npm run build"
+publish = "dist/client"

--- a/scripts/templates/demo-store/vite.config.js
+++ b/scripts/templates/demo-store/vite.config.js
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+import hydrogen from '@shopify/hydrogen/plugin'
+import netlifyPlugin from '@netlify/hydrogen-platform/plugin'
+
+export default defineConfig({
+  plugins: [hydrogen(), netlifyPlugin()],
+  resolve: {
+    alias: [{ find: /^~\/(.*)/, replacement: '/src/$1' }],
+  },
+  optimizeDeps: {
+    include: ['@headlessui/react', 'clsx', 'react-use', 'typographic-base'],
+  },
+  test: {
+    globals: true,
+    testTimeout: 10000,
+    hookTimeout: 10000,
+  },
+})

--- a/scripts/templates/hello-world/netlify.toml
+++ b/scripts/templates/hello-world/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "cd ../../ && npm run build && cd - && npm run build"
+publish = "dist/client"

--- a/scripts/templates/hello-world/vite.config.js
+++ b/scripts/templates/hello-world/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import hydrogen from '@shopify/hydrogen/plugin'
+import netlifyPlugin from '@netlify/hydrogen-platform/plugin'
+
+export default defineConfig({
+  plugins: [hydrogen(), netlifyPlugin()],
+})

--- a/scripts/update-demos.mjs
+++ b/scripts/update-demos.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+import { existsSync } from 'node:fs'
+import { cp, rm, readdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+const source = resolve('upstream', 'templates')
+const destination = resolve('demos')
+if (existsSync(destination)) {
+  await rm(destination, { recursive: true })
+}
+
+if (!existsSync(source)) {
+  console.error(`Could not find templates at ${source}`)
+  process.exit(1)
+}
+
+await cp(source, destination, {
+  recursive: true,
+})
+
+async function addPlatformDependency(root) {
+  const packageJsonFile = resolve(root, 'package.json')
+  if (!existsSync(packageJsonFile)) {
+    return
+  }
+  const templatePackageJson = JSON.parse(
+    await readFile(packageJsonFile, 'utf8')
+  )
+  templatePackageJson.devDependencies['@netlify/hydrogen-platform'] =
+    'file:../..'
+  await writeFile(packageJsonFile, JSON.stringify(templatePackageJson, null, 2))
+}
+
+const templates = await readdir(destination)
+for (const template of templates) {
+  if (!template.endsWith('-js') && !template.endsWith('-ts')) {
+    continue
+  }
+  const templateDir = resolve(destination, template)
+  await addPlatformDependency(templateDir)
+  // Strip the -ts or -js from the name
+  const normalizedTemplate = template.slice(0, -3)
+  await cp(resolve('scripts', 'templates', normalizedTemplate), templateDir, {
+    recursive: true,
+  })
+}


### PR DESCRIPTION
Provides a workflow and script to automatically update demo sites from the Hydrogen repo. Once this is merged we can set it up to run nightly. These sites are the ones used by the Hydrogen CLI. The script pulls the latest version from the repo, applies patches to make it work on Netlify, then opens a PR. 