### PR TITLE
fix: correct dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,11 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@shopify/hydrogen": "^1.0.1",
-        "@types/node": "^17.0.23",
         "execa": "^6.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
         "tsup": "^6.0.0",
-        "typescript": "^4.6.3",
-        "vite": "^2.9.1"
+        "typescript": "^4.0.0"
       },
       "peerDependencies": {
         "@shopify/hydrogen": "^1.0.0"
@@ -13273,16 +13270,23 @@
     },
     "packages/platform": {
       "name": "@netlify/hydrogen-platform",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@netlify/vite-plugin-netlify-edge": "^1.1.0",
         "magic-string": "^0.26.1"
       },
       "devDependencies": {
+        "@shopify/hydrogen": "^1.2.0",
+        "@types/node": "^17.0.23",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "tsup": "^6.0.0"
+        "tsup": "^6.0.0",
+        "typescript": "^4.0.0",
+        "vite": "^2.9.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0"
       }
     }
   },
@@ -14015,10 +14019,14 @@
       "version": "file:packages/platform",
       "requires": {
         "@netlify/vite-plugin-netlify-edge": "^1.1.0",
+        "@shopify/hydrogen": "^1.2.0",
+        "@types/node": "^17.0.23",
         "magic-string": "^0.26.1",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "tsup": "^6.0.0"
+        "tsup": "^6.0.0",
+        "typescript": "^4.0.0",
+        "vite": "^2.9.0"
       }
     },
     "@netlify/vite-plugin-netlify-edge": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,11 @@
     "@shopify/hydrogen": "^1.0.0"
   },
   "devDependencies": {
-    "@shopify/hydrogen": "^1.0.1",
-    "@types/node": "^17.0.23",
     "execa": "^6.1.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "tsup": "^6.0.0",
-    "typescript": "^4.6.3",
-    "vite": "^2.9.1"
+    "typescript": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -41,9 +41,16 @@
     "@netlify/vite-plugin-netlify-edge": "^1.1.0",
     "magic-string": "^0.26.1"
   },
+  "peerDependencies": {
+    "vite": "^2.9.0"
+  },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "tsup": "^6.0.0"
+    "tsup": "^6.0.0",
+    "typescript": "^4.0.0",
+    "@shopify/hydrogen": "^1.2.0",
+    "@types/node": "^17.0.23",
+    "vite": "^2.9.0"
   }
 }


### PR DESCRIPTION
After moving the plugin into a workspace, some of the dependencies were in the wrong place, meaning releases weren't happening correctly