### PR TITLE
fix: import paths from hydrogen not using magic strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
         "demos/*",
         "packages/*"
       ],
-      "dependencies": {
-        "magic-string": "^0.26.1"
-      },
       "devDependencies": {
         "execa": "^6.1.0",
         "npm-run-all": "^4.1.5",
@@ -13641,8 +13638,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@netlify/vite-plugin-netlify-edge": "^1.1.0",
-        "magic-string": "^0.26.1"
+        "@netlify/vite-plugin-netlify-edge": "^1.1.0"
       },
       "devDependencies": {
         "@shopify/hydrogen": "^1.2.0",
@@ -14400,7 +14396,6 @@
         "@netlify/vite-plugin-netlify-edge": "^1.1.0",
         "@shopify/hydrogen": "^1.2.0",
         "@types/node": "^17.0.23",
-        "magic-string": "^0.26.1",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
         "tsup": "^6.0.0",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -38,19 +38,18 @@
   },
   "homepage": "https://github.com/netlify/hydrogen-platform#readme",
   "dependencies": {
-    "@netlify/vite-plugin-netlify-edge": "^1.1.0",
-    "magic-string": "^0.26.1"
+    "@netlify/vite-plugin-netlify-edge": "^1.1.0"
   },
   "peerDependencies": {
     "vite": "^2.9.0"
   },
   "devDependencies": {
+    "@shopify/hydrogen": "^1.2.0",
+    "@types/node": "^17.0.23",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "tsup": "^6.0.0",
     "typescript": "^4.0.0",
-    "@shopify/hydrogen": "^1.2.0",
-    "@types/node": "^17.0.23",
     "vite": "^2.9.0"
   }
 }

--- a/packages/platform/src/handler.ts
+++ b/packages/platform/src/handler.ts
@@ -1,14 +1,10 @@
-// @ts-ignore Replaced by vite during compilation
-import entrypoint from '__SERVER_ENTRY__'
-// @ts-ignore
-import indexTemplate from '__INDEX_TEMPLATE__?raw'
+import { handleRequest, indexTemplate } from '@shopify/hydrogen/platforms'
 // @ts-ignore
 import staticPaths from '@static-manifest'
 
 import { InMemoryCache } from '@shopify/hydrogen/cache/in-memory'
-import { RequestHandler, RuntimeContext } from '@shopify/hydrogen/types'
+import { RuntimeContext } from '@shopify/hydrogen/types'
 
-const handleRequest = entrypoint as RequestHandler
 const memoryCache = new InMemoryCache()
 
 ;(globalThis as any).Oxygen ||= {}

--- a/packages/platform/src/plugin.ts
+++ b/packages/platform/src/plugin.ts
@@ -1,11 +1,6 @@
 import netlifyPlugin from '@netlify/vite-plugin-netlify-edge'
-import { normalizePath } from 'vite'
-import path from 'path'
-import MagicString from 'magic-string'
 
 import type { Plugin, ResolvedConfig } from 'vite'
-
-const HYDROGEN_DEFAULT_SERVER_ENTRY = '/src/App.server'
 
 const plugin = (): Array<Plugin> => {
   let resolvedConfig: ResolvedConfig
@@ -30,34 +25,6 @@ const plugin = (): Array<Plugin> => {
       configResolved(config) {
         // Save the config for later use
         resolvedConfig = config
-      },
-      transform(code, id) {
-        // Replace the magic strings in the server entrypoint with the correct values
-        if (normalizePath(id) === platformEntrypoint) {
-          code = code
-            .replace(
-              '__SERVER_ENTRY__',
-              process.env.HYDROGEN_SERVER_ENTRY || HYDROGEN_DEFAULT_SERVER_ENTRY
-            )
-            .replace(
-              '__INDEX_TEMPLATE__',
-              process.env.HYDROGEN_INDEX_TEMPLATE ||
-                normalizePath(
-                  path.resolve(
-                    resolvedConfig.root,
-                    'dist',
-                    'client',
-                    'index.html'
-                  )
-                )
-            )
-
-          const ms = new MagicString(code)
-          return {
-            code: ms.toString(),
-            map: ms.generateMap({ file: id, source: id }),
-          }
-        }
       },
     },
   ]


### PR DESCRIPTION
Fixes issue #71 

The build was tested with `demos/demo-store-ts` and published to Netlify by manual deploying.
You can see the preview [here](https://63353e672e232c56f99e89bd--hydrogen-netlify-starter-testvp.netlify.app/)