### PR TITLE
chore: fix deprecated set-output github workflow command

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,8 +25,8 @@ jobs:
           tag_version=${branch:9}
           tag=${tag_version%/*}
           version=${tag_version##*/}
-          echo "::set-output name=tag::${tag}"
-          echo "::set-output name=version::${version}"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Log versions
         run: |-
           echo tag=${{ steps.extract.outputs.tag }}


### PR DESCRIPTION
### Summary

GitHub is [deprecating the `set-output` workflow command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in actions after 31st May 2023.

This PR changes the GitHub workflow to use the new format. 

### Test plan

1. Check that the PR actions work as expected with a pre-release

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/1965510/218683297-d1221e46-87df-4ae5-95c1-109638b6b11a.png)

### Standard checks:

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---
